### PR TITLE
:bug: Fix unlock command (chapters were wrong)

### DIFF
--- a/src/commands/campaignProgress.js
+++ b/src/commands/campaignProgress.js
@@ -1,21 +1,21 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
 
 const campaign = [
-    { chapter: 0, levels: 5, totalProgress: "0-5", unlocks: [] },
-    { chapter: 1, levels: 20, totalProgress: "6-25", unlocks: ["**Mines of Abyss (unlock at half chapter)**"] },
-    { chapter: 2, levels: 20, totalProgress: "26-45", unlocks: ["**Tower of Darkness**", "**Apprentice Gear (green)**"] },
-    { chapter: 3, levels: 20, totalProgress: "46-65", unlocks: ["**Utopia of Dragon**"] },
-    { chapter: 4, levels: 40, totalProgress: "66-105", unlocks: ["**Labyrinth of Madness**", "**Hall of Honor (unlock at half chapter)**"] },
-    { chapter: 5, levels: 40, totalProgress: "106-145", unlocks: ["**Adept Gear (blue)**"] },
-    { chapter: 6, levels: 40, totalProgress: "146-185", unlocks: ["**Apprentice Universal Soul (green)**", "**Class Towers of Darkness**"] },
-    { chapter: 7, levels: 40, totalProgress: "186-225", unlocks: [] },
-    { chapter: 8, levels: 40, totalProgress: "226-265", unlocks: ["**Rare Adept Gear (purple)**"] },
-    { chapter: 9, levels: 40, totalProgress: "266-305", unlocks: ["**Adept Universal Soul (blue)**"] },
-    { chapter: 10, levels: 40, totalProgress: "306-345", unlocks: [] },
-    { chapter: 11, levels: 40, totalProgress: "346-385", unlocks: ["**Master Gear (pink)**"] },
-    { chapter: 12, levels: 40, totalProgress: "386-425", unlocks: ["**Master Universal Soul (purple)**"] },
-    { chapter: 13, levels: 40, totalProgress: "426-465", unlocks: [] },
-    { chapter: 14, levels: 40, totalProgress: "466-505", unlocks: [] },
+    { chapter: 1, levels: 5, totalProgress: "1-5", unlocks: [] },
+    { chapter: 2, levels: 20, totalProgress: "6-25", unlocks: ["**Mines of Abyss (unlock at half chapter)**"] },
+    { chapter: 3, levels: 20, totalProgress: "26-45", unlocks: ["**Tower of Darkness**", "**Apprentice Gear (green)**"] },
+    { chapter: 4, levels: 20, totalProgress: "46-65", unlocks: ["**Utopia of Dragon**"] },
+    { chapter: 5, levels: 40, totalProgress: "66-105", unlocks: ["**Labyrinth of Madness**", "**Hall of Honor (unlock at half chapter)**"] },
+    { chapter: 6, levels: 40, totalProgress: "106-145", unlocks: ["**Adept Gear (blue)**"] },
+    { chapter: 7, levels: 40, totalProgress: "146-185", unlocks: ["**Apprentice Universal Soul (green)**", "**Class Towers of Darkness**"] },
+    { chapter: 8, levels: 40, totalProgress: "186-225", unlocks: [] },
+    { chapter: 9, levels: 40, totalProgress: "226-265", unlocks: ["**Rare Adept Gear (purple)**"] },
+    { chapter: 10, levels: 40, totalProgress: "266-305", unlocks: ["**Adept Universal Soul (blue)**"] },
+    { chapter: 11, levels: 40, totalProgress: "306-345", unlocks: [] },
+    { chapter: 12, levels: 40, totalProgress: "346-385", unlocks: ["**Master Gear (pink)**"] },
+    { chapter: 13, levels: 40, totalProgress: "386-425", unlocks: ["**Master Universal Soul (purple)**"] },
+    { chapter: 14, levels: 40, totalProgress: "426-465", unlocks: [] },
+    { chapter: 15, levels: 40, totalProgress: "466-505", unlocks: [] },
 ]
 
 function generateProgressList() {


### PR DESCRIPTION
Ha sorry for yet another mistake on this damn command. But their data is very misleading. Chapter 0 in the data is actually chapter 1 for the players, as I explained in discord general chat.

Hopefully this is the last fix.